### PR TITLE
Add standard Python .gitignore for cleaner repository

### DIFF
--- a/gwc-siemcode/.gitignore
+++ b/gwc-siemcode/.gitignore
@@ -1,0 +1,66 @@
+# ------------------------------
+# Python build and cache files
+# ------------------------------
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# ------------------------------
+# Virtual environments
+# ------------------------------
+.venv/
+venv/
+ENV/
+env/
+env.bak/
+venv.bak/
+
+# ------------------------------
+# SQLite databases & local storage
+# ------------------------------
+*.db
+*.sqlite
+*.sqlite3
+
+# ------------------------------
+# Logs and runtime files
+# ------------------------------
+*.log
+*.pid
+*.csv
+
+# ------------------------------
+# Environment and config
+# ------------------------------
+.env
+.env.*
+config.yaml
+config.yml
+
+# ------------------------------
+# Jupyter / Notebooks
+# ------------------------------
+.ipynb_checkpoints
+*.ipynb
+
+# ------------------------------
+# OS / Editor / IDE files
+# ------------------------------
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# ------------------------------
+# Distribution / packaging
+# ------------------------------
+build/
+dist/
+*.egg-info/
+*.egg
+MANIFEST


### PR DESCRIPTION
This PR adds a .gitignore file tailored for the gwc-siem Python project.
It helps keep the repository clean by excluding:

1) Python cache and build files

2) Virtual environments (.venv, venv/)

3) SQLite databases and logs

4) Editor and OS-specific files (VS Code, .DS_Store, etc.)

This ensures contributors don’t accidentally commit environment or local data files.